### PR TITLE
fix: adding return value for the goldenContainer data mixin

### DIFF
--- a/src/roles/container.ts
+++ b/src/roles/container.ts
@@ -9,6 +9,7 @@ import { genericTemplate } from '../golden.vue'
 			vm.groupColor = allocateColor();
 		else if(vm.belongGroupColor)
 			vm.groupColor = vm.belongGroupColor;
+		return {}
 	}
 }]})
 export class goldenContainer extends goldenItem {


### PR DESCRIPTION
close #77 
Trying on the basis that vue-apollo / vue-golden-layout clashing appears
to be because a data object is undefined.

It seems also fix state lost issue using with v-if